### PR TITLE
enhance: /login entry point (#1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+sanic
+argon2
+pyjwt
+sqlalchemy

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,6 @@
+from sanic import Blueprint
+from sanic.response import text
+
+from .login import login
+
+api = Blueprint.group(login, url_prefix='/api')

--- a/src/api/login.py
+++ b/src/api/login.py
@@ -1,0 +1,23 @@
+from sanic import Blueprint
+from sanic.response import json, text
+from sanic.exceptions import InvalidUsage, Unauthorized
+
+import auth
+import model
+import util
+
+login = Blueprint('login')
+
+
+@login.route('/login', methods=['POST'], version=1)
+async def login_handler(request):
+    data = util.validate_post_request(request, ['username', 'password'])
+    user = request.app.session.query(
+        model.User).filter_by(username=data['username']).first()
+    # Mitigation of time-attack
+    user = user if user else model.User('', '')
+    if auth.check_password(data['password'], user.password, user.salt):
+        token = await auth.issue_token(user.username, request.app.jwt_secret)
+        return json({'token': token})
+    else:
+        raise Unauthorized('Wrong username or password')

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,26 @@
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy import create_engine
+
+from sanic import Sanic
+from api import api
+
+from secrets import token_hex
+
+import config
+import model
+import auth
+
+if __name__ == '__main__':
+    engine = create_engine(config.db_uri, echo=True)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    model.Base.metadata.create_all(engine)
+
+    app = Sanic(__name__)
+    app.blueprint(api, version=1)
+    app.jwt_secret = token_hex(auth.jwt_secret_length)
+
+    app.session = session
+    app.run(host=config.host, port=config.port, debug=config.debug)
+
+    session.close_all()

--- a/src/auth.py
+++ b/src/auth.py
@@ -1,0 +1,95 @@
+from argon2 import argon2_hash
+from secrets import token_hex
+from hashlib import sha256
+from sanic.exceptions import Unauthorized
+import jwt
+import datetime
+from functools import wraps
+import re
+
+import model
+
+# Since I'm using JWT with the HS256 hashing algorithm, 256 bits (32 bytes) is enough
+salt_length = jwt_secret_length = 32
+
+
+def hashed_password(password: str, salt: str = None) -> (str, str):
+    '''
+    Prepares typed-in password to be dumped to the db. Basically it's just:
+    sha256(sha256(password) + salt) with some sort of permutations.
+    I'm not considering using of the pepper thing because of its several flaws that
+    make it pretty much useless. Read more at https://stackoverflow.com/a/16896216
+    '''
+    salt = salt if salt else token_hex(salt_length)
+    return (argon2_hash(password, salt).hex(), salt)
+
+
+async def issue_token(username: str, secret: str, exp_time: int = 3600) -> str:
+    '''
+    Using JSON Web Token algorithm signs up the payload of a token being issued
+    with the secret, that makes it impossible to forge or modify the token contents.
+    The secret is a random sequence of bytes that is the same for every user
+    and being set when sanic starts.
+    You could think of it as a environment variable.
+    It is possible to specify the life time of a token in seconds with exp_time.
+    Default value is an hour.
+    '''
+    payload = {
+        'sub': username,
+        'exp': datetime.datetime.utcnow() + datetime.timedelta(seconds=exp_time),
+    }
+    return jwt.encode(payload, secret).decode('utf8')
+
+
+async def verify_token(token: str, secret: str, session) -> (bool, str):
+    '''
+    Returns (True, '') if a token passes varification,
+    otherwise returns (False, "Reason").
+    '''
+    if token == '':
+        return (False, 'Token is missing')
+    try:
+        token = token.encode('utf8')
+    except UnicodeEncodeError as e:
+        return (False, e.reason)
+
+    try:
+        decoded = jwt.decode(token, secret)
+    except jwt.PyJWTError as e:
+        return (False, e.args[0])
+
+    if 'sub' not in decoded:
+        return (False, 'Token subject is missing')
+
+    user = session.query(model.User).filter_by(username=decoded['sub']).first()
+    if not user:
+        return (False, 'Token subject doesn\'t exist')
+
+    return (True, '')
+
+
+def check_password(typed: str, hashed: str, salt: str) -> bool:
+    return hashed == hashed_password(typed, salt=salt)[0]
+
+
+def get_token(request) -> str:
+    if 'Authorization' in request.headers:
+        result = re.findall('Bearer ([\w\._-]+)',
+                            request.headers['Authorization'])
+        if len(result) == 1:
+            return result[0]
+    return ''
+
+
+def auth_required(handler=None):
+    @wraps(handler)
+    async def wrapper(request, *args, **kwargs):
+        auth = await verify_token(get_token(request),
+                                  request.app.jwt_secret,
+                                  request.app.session)
+        if not auth[0]:
+            raise Unauthorized(
+                "Authentication error: {}".format(auth[1]))
+        return await handler(request, *args, **kwargs)
+
+    return wrapper

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,4 @@
+db_uri = 'sqlite:///db/db.sqlite'
+host = '0.0.0.0'
+port = 8000
+debug = True

--- a/src/model.py
+++ b/src/model.py
@@ -1,0 +1,28 @@
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+import auth
+
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = 'users'
+    id = Column(Integer, primary_key=True)
+    username = Column(String)
+    password = Column(String)
+    salt = Column(String)
+
+    def __init__(self, username, password):
+        self.username = username
+        self.password, self.salt = auth.hashed_password(password)
+
+    def __repr__(self):
+        return 'User(username={})'.format(self.username)
+
+    def to_dict(self):
+        result = {}
+        for column in self.__table__.columns:
+            result[column.name] = str(getattr(self, column.name))
+        return result

--- a/src/util.py
+++ b/src/util.py
@@ -1,0 +1,25 @@
+from sanic.exceptions import InvalidUsage
+from sanic.request import Request
+
+
+def validate_post_request(request: Request, fields: [str]) -> dict:
+    '''
+    Throws InvalidUsage exception if any given field is missing
+    in the request body or URL arguments (in this order).
+    '''
+    error_message = 'Invalid request format. Mandatory fields are missing: {}'
+    if not request.json and not request.args:
+        raise InvalidUsage(error_message.format(repr(fields)))
+    for source in [request.json, request.args]:
+        if source:
+            missing = [field for field in fields if field not in source]
+            if len(missing):
+                raise InvalidUsage(error_message.format(repr(missing)))
+            else:
+                return strip_list(source)
+
+
+def strip_list(data: dict) -> dict:
+    for k, v in data.items():
+        data[k] = v if isinstance(v, str) else v[0]
+    return data


### PR DESCRIPTION
Login entry point implementation.
It uses `argon2` for password hashing with 32 bytes of crypto-random salt, the password is never stored in plain-text. The salt is stored along with the password in the same table. `JWT` is for token issuing and checking its sigh. After successful login you get a token which you have to place in your `Authorization: Bearer <token>` in order to get access to a resource with authorization required. There's a decorator `@auth.auth_required` that you can place between your router decorator declaration and the definition of a route handler. Like:
```
@bp.route('/path', methods=['GET'], version=1)
@auth.auth_required
async def protected(request):
    return text('protected data')
```
Also, there are two methods of passing the credentials are allowed: JSON object in request body and URL arguments. The first one is prioritized over the second.