### PR TITLE
fix: tests: multiple changes

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,10 +1,17 @@
-#!/bin/zsh
+#!/bin/sh
+
+pip --version 2>&1 > /dev/null
+if [ $? -ne 0 ]; then
+    echo "You have to install 'pip' using your system packet manager first"
+    echo "Exit"
+    exit 1
+fi
 
 base=`realpath "$(dirname "${BASH_SOURCE[0]}")"`
 cd "$base"
 
-host=`cat src/config.py 2>/dev/null | grep host | awk -F= '{print $2}' | xargs`
-port=`cat src/config.py 2>/dev/null | grep port | awk -F= '{print $2}' | xargs`
+host=`cat src/config_test.py 2>/dev/null | grep host | awk -F= '{print $2}' | xargs`
+port=`cat src/config_test.py 2>/dev/null | grep port | awk -F= '{print $2}' | xargs`
 
 if [ -z "$host" ] || [ -z "$port" ]; then
    echo "Configuration file is missing or corrupt"
@@ -13,14 +20,16 @@ if [ -z "$host" ] || [ -z "$port" ]; then
 fi
 
 if [ -z "$VIRTUAL_ENV" ]; then
+    pip install --user virtualenv virtualenv-bin
+    PATH=$PATH:~/.local/bin
     mkdir venv 2>/dev/null
-    [ $? -eq 0 ] && virtualenv ./venv/ 2>/dev/null
+    [ $? -eq 0 ] && virtualenv ./venv/ 2>/dev/null && VENV_CREATED=1
 fi
 
 source ./venv/bin/activate
 pip install -r requirements-dev.txt
+rm src/db/test_db.sqlite 2>/dev/null
 python3 ./tests/create_test_user.py
-
 
 running=`lsof -Pi TCP@$host:$port -t`
 if [ -z "$running" ]; then
@@ -39,6 +48,11 @@ fi
 pyresttest "http://$host:$port" ./tests/*.yaml
 
 ([ $? -eq 0 ] && echo "Done!" ) || echo "Fail!"
+
+if [ $VENV_CREATED -eq 1 ]; then
+    deactivate
+    rm -r ./venv
+fi
 
 # if the server has been started in this process, shut it down
 # (there's probably a better way to do this, but I don't know it)

--- a/src/app.py
+++ b/src/app.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy import create_engine
 
@@ -5,12 +6,27 @@ from sanic import Sanic
 from api import api
 
 from secrets import token_hex
+import argparse
+import os
+import imp
 
-import config
 import model
 import auth
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Main entry point')
+    parser.add_argument('--config', '-c', dest='config',
+                        action='store', default='config_test.py')
+    args = parser.parse_args()
+    config_file = os.path.expanduser(args.config)
+    if not os.path.isfile(config_file):
+        raise FileNotFoundError(
+            'Configuration file \'{}\' doesn\'t exist'.format(config_file))
+    try:
+        config = imp.load_source('config', config_file)
+    except Exception as e:
+        raise ImportError(
+            'Specified configuration file doesn\'t seem to be a correct python file')
     engine = create_engine(config.db_uri, echo=config.sql_debug)
     Session = sessionmaker(bind=engine)
     session = Session()

--- a/src/config_production.py
+++ b/src/config_production.py
@@ -1,5 +1,5 @@
 db_uri = 'sqlite:///db/db.sqlite'
 host = '0.0.0.0'
 port = 8000
-sql_debug = True
-sanic_debug = True
+sql_debug = False
+sanic_debug = False

--- a/src/config_test.py
+++ b/src/config_test.py
@@ -1,0 +1,5 @@
+db_uri = 'sqlite:///db/test_db.sqlite'
+host = '0.0.0.0'
+port = 8000
+sql_debug = True
+sanic_debug = True

--- a/tests/create_test_user.py
+++ b/tests/create_test_user.py
@@ -19,11 +19,12 @@ from sqlalchemy import create_engine
 
 
 import model
-import config
+import config_test as config
 
 engine = create_engine(config.db_uri, echo=config.sql_debug)
 Session = sessionmaker(bind=engine)
 session = Session()
+model.Base.metadata.create_all(engine)
 user = session.query(model.User).filter_by(username='test').first()
 if not user:
     session.add(model.User('test', 'test'))


### PR DESCRIPTION
Since now it's possible to specify a configuration file as a main entry point `app.py` CLI parameter. There are two default configs included in the repository. Even though `config_test.py` is used by default, you're able to use any correct python file across your system. Database file removed from the repository tracking and now it's split into 2 separate files to prevent production database damage during running the tests.
Also there is a few changes in `run_tests.sh` aimed the tests to be more likely to run in different environments and its results to be more predictable.