### PR TITLE
Captcha

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/faptcha"]
+	path = src/faptcha
+	url = https://github.com/nogaems/faptcha.git

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,5 @@ sanic
 argon2
 pyjwt
 sqlalchemy
+pillow
 pyresttest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ sanic
 argon2
 pyjwt
 sqlalchemy
+pillow

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -2,5 +2,6 @@ from sanic import Blueprint
 from sanic.response import text
 
 from .login import login
+from .captcha import captcha
 
-api = Blueprint.group(login, url_prefix='/api')
+api = Blueprint.group(login, captcha, url_prefix='/api')

--- a/src/api/captcha.py
+++ b/src/api/captcha.py
@@ -1,0 +1,35 @@
+from sanic import Blueprint
+from sanic.response import json, raw
+
+import auth
+import util
+
+captcha = Blueprint('captcha')
+
+
+@captcha.route('/captcha', methods=['GET'], version=1)
+async def get_captcha(request):
+    img, id = request.app.captcha.get()
+    return raw(img,
+               content_type='image/png',
+               headers={'content-disposition': 'inline; filename={}.png'.format(id)})
+
+
+@captcha.route('/captcha', methods=['POST'], version=1)
+async def post_captcha(request):
+    data = util.validate_post_request(request, ['id', 'code'])
+    if request.app.captcha.check(data['id'], data['code'], delete=False):
+        status = 200
+        body = {'token': await auth.issue_token(
+            {'id': data['id']}, request.app.jwt_secret,
+            exp_time=request.app.cfg.captcha_timeout)}
+    else:
+        status = 422
+        body = {'error': 'Wrong CAPTCHA code'}
+    return json(body, status=status)
+
+
+@captcha.route('/captcha', methods=['PUT'], version=1)
+async def utilize_captcha(request):
+    util.process_captcha(request)
+    return json({'status': 'ok'})

--- a/src/api/login.py
+++ b/src/api/login.py
@@ -17,7 +17,9 @@ async def login_handler(request):
     # Mitigation of time-attack
     user = user if user else model.User('', '')
     if auth.check_password(data['password'], user.password, user.salt):
-        token = await auth.issue_token(user.username, request.app.jwt_secret)
+        token = await auth.issue_token({'sub': user.username},
+                                       request.app.jwt_secret,
+                                       exp_time=request.app.cfg.auth_token_timeout)
         return json({'token': token})
     else:
         raise Unauthorized('Wrong username or password')

--- a/src/app.py
+++ b/src/app.py
@@ -5,6 +5,8 @@ from sqlalchemy import create_engine
 from sanic import Sanic
 from api import api
 
+from faptcha import captcha
+
 from secrets import token_hex
 import argparse
 import os
@@ -37,6 +39,8 @@ if __name__ == '__main__':
     app.jwt_secret = token_hex(auth.jwt_secret_length)
 
     app.session = session
+    app.captcha = captcha.Captcha()
+    app.cfg = config
     app.run(host=config.host, port=config.port, debug=config.sanic_debug)
 
     session.close_all()

--- a/src/config_production.py
+++ b/src/config_production.py
@@ -3,3 +3,6 @@ host = '0.0.0.0'
 port = 8000
 sql_debug = False
 sanic_debug = False
+captcha_timeout = 180
+auth_token_timeout = 3600
+

--- a/src/config_test.py
+++ b/src/config_test.py
@@ -3,3 +3,5 @@ host = '0.0.0.0'
 port = 8000
 sql_debug = True
 sanic_debug = True
+captcha_timeout = 180
+auth_token_timeout = 3600

--- a/src/util.py
+++ b/src/util.py
@@ -1,6 +1,8 @@
 from sanic.exceptions import InvalidUsage
 from sanic.request import Request
 
+import auth
+
 
 def validate_post_request(request: Request, fields: [str]) -> dict:
     '''
@@ -23,3 +25,55 @@ def strip_list(data: dict) -> dict:
     for k, v in data.items():
         data[k] = v if isinstance(v, str) else v[0]
     return data
+
+
+def check_id(request, decoded):
+    if decoded['id'] in request.app.captcha.storage:
+        request.app.captcha.remove_from_storage(decoded['id'])
+        return (True, '')
+    else:
+        return (False, 'This captcha is already used')
+
+
+def cleanup_fn(request, decoded):
+    if 'id' in decoded:
+        if decoded['id'] in request.app.captcha.storage:
+            request.app.captcha.remove_from_storage(decoded['id'])
+
+
+def process_captcha(request: Request):
+    '''
+    This function must be used in places where captcha authentication is required.
+    Captcha has to be either an entry of the request body
+    {...'captcha': {'id': int, 'code': int}...}
+    or a custom header of this format:
+    'X-Captcha-Token: <value>', where value is a JWT-signed token.
+    Throws InvalidUsage exception if provided captcha code is wrong, captcha token
+    is invalid (e.g. it's forged and it doesn't pass sign check), the token is
+    expired or there's no captcha provided at all.
+    This function prioritizes the token from the headers over json data from
+    the request body.
+    After calling this function provided captcha is fully utilized and
+    cannot be used again.
+
+    '''
+    if 'x-captcha-token' in request.headers:
+        token = request.headers['x-captcha-token']
+        result, reason = auth.verify_token(token, request,
+                                           required_fields=['id'],
+                                           verification_fn=check_id,
+                                           exp_hook_fn=cleanup_fn)
+        if not result:
+            raise InvalidUsage(reason)
+        else:
+            return
+
+    json = request.json
+    if not json or 'captcha' not in json:
+        return InvalidUsage('No CAPTCHA provided')
+    elif 'id' not in json['captcha'] or 'code' not in json:
+        return InvalidUsage('Wrong CAPTCHA object structure')
+    else:
+        if not request.app.captcha.check(json['captcha']['id'],
+                                         json['captcha']['code']):
+            raise InvalidUsage('Wrong CAPTCHA code')

--- a/src/util.py
+++ b/src/util.py
@@ -28,7 +28,7 @@ def strip_list(data: dict) -> dict:
 
 
 def check_id(request, decoded):
-    if decoded['id'] in request.app.captcha.storage:
+    if request.app.captcha.is_issued(decoded['id']):
         request.app.captcha.remove_from_storage(decoded['id'])
         return (True, '')
     else:
@@ -37,7 +37,7 @@ def check_id(request, decoded):
 
 def cleanup_fn(request, decoded):
     if 'id' in decoded:
-        if decoded['id'] in request.app.captcha.storage:
+        if request.app.captcha.is_issued(decoded['id']):
             request.app.captcha.remove_from_storage(decoded['id'])
 
 


### PR DESCRIPTION
add: /captcha endpoint

There are two ways to use this endpoint:
1) Use GET request to obtain a captcha, use POST request to send its code and get a token, put that token in request headers as 'X-Captcha-Token: <value>' and you will be allowed to perform a request on endpoints requiring captcha authorization. After single usage this captcha becomes unusable. The token has relatively short expiration time, but this time is enough to send a form.
2) Send captcha structure along with the rest request body as a part of json object with the following syntax:
{...{'captcha': {'id': <value>, 'code': <value>}}...}
Note that the first method is prioritized over the second one.
Also, you can use PUT request for testing purposes. It does nothing besides consuming provided captcha and returning status code 200 if everything went correct, otherwise it tells what's happened.